### PR TITLE
Bring ETag back and rework caching solution

### DIFF
--- a/src/main/java/org/apereo/openequella/adminconsole/launcher/ClientLauncher.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/launcher/ClientLauncher.java
@@ -339,7 +339,7 @@ public class ClientLauncher extends JFrame implements ActionListener, WindowList
               .map(Path::toFile)
               .forEach(File::delete);
         } catch (Exception e) {
-          LOGGER.error("Problem launching client", e);
+          LOGGER.error("Problem removing client", e);
           JOptionPane.showMessageDialog(
               ClientLauncher.this, "Problem removing server: " + e.getMessage());
         }

--- a/src/main/java/org/apereo/openequella/adminconsole/launcher/ClientLauncher.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/launcher/ClientLauncher.java
@@ -339,7 +339,7 @@ public class ClientLauncher extends JFrame implements ActionListener, WindowList
               .map(Path::toFile)
               .forEach(File::delete);
         } catch (Exception e) {
-          LOGGER.error("Problem removing client", e);
+          LOGGER.error("Problem removing server", e);
           JOptionPane.showMessageDialog(
               ClientLauncher.this, "Problem removing server: " + e.getMessage());
         }

--- a/src/main/java/org/apereo/openequella/adminconsole/service/JarService.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/service/JarService.java
@@ -44,10 +44,10 @@ public class JarService {
 	private final File cacheFolder;
 	private final File binFolder;
 
-	public JarService(String baseUrl) {
+	public JarService(String baseUrl, String uuid) {
 		this.baseUrl = baseUrl;
-		this.cacheFolder = StorageService.getFolder("cache");
-		this.binFolder = StorageService.getFolder("bin");
+		this.cacheFolder = StorageService.getCacheFolder(uuid,"cache");
+		this.binFolder = StorageService.getCacheFolder(uuid,"bin");
 	}
 
 	public void ensureBinJars(String... jarNames) {
@@ -94,6 +94,7 @@ public class JarService {
 
 				if (metadataFile.exists()) {
 					final JarMetadata meta = JsonService.readFile(metadataFile, JarService.JarMetadata.class);
+					conn.setRequestProperty("If-None-Match", meta.getEtag());
 					conn.setRequestProperty("If-Modified-Since", meta.getModifiedDate());
 				}
 				conn.connect();

--- a/src/main/java/org/apereo/openequella/adminconsole/service/StorageService.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/service/StorageService.java
@@ -37,8 +37,16 @@ public class StorageService {
 		return new File(folder, fileName);
 	}
 
-	public static File getFolder(String folderName){
-		final File folder = new File(getBaseFolder(), folderName);
+	public static File getServerConfigFolder(String uuid) {
+		final File folder = new File(getBaseFolder(), uuid);
+		if (!folder.exists()){
+			folder.mkdir();
+		}
+		return folder;
+	}
+
+	public static File getCacheFolder(String uuid, String folderName){
+		final File folder = new File(getServerConfigFolder(uuid), folderName);
 		if (!folder.exists()){
 			folder.mkdir();
 		}


### PR DESCRIPTION
* Add ETag back to downloading requests

* For each server, the launcher will create a specific cache directory so that each server will have their own cached JARs and configurations

* The launcher will remove the cache directory when users remove a specific server