### PR TITLE
Display a dialog for better user experience

### DIFF
--- a/src/main/java/org/apereo/openequella/adminconsole/service/JarService.java
+++ b/src/main/java/org/apereo/openequella/adminconsole/service/JarService.java
@@ -134,7 +134,6 @@ public class JarService {
 	}
 
 	public int executeJar(String jarName, String mainClass, String... jvmArgs) {
-		ensureBinJars(jarName);
 		final File binJar = getBinJarFile(jarName);
 		final List<String> command = new ArrayList<>();
 		command.add("java");


### PR DESCRIPTION
* Display a dialog after clicking the launch button,  and close this dialog when admin console is about to run or when exceptions happen 

* Re-display the launcher after closing admin console
 